### PR TITLE
Ansible version tag

### DIFF
--- a/.github/workflows/build-and-publish-ansible.yaml
+++ b/.github/workflows/build-and-publish-ansible.yaml
@@ -45,7 +45,7 @@ jobs:
         run: |
           ANSIBLE_VERSION="$(docker run --rm ghcr.io/xima-media/debian-ansible:test ansible-community --version | cut -d' ' -f4-)"
           echo "$ANSIBLE_VERSION"
-          echo "$ANSIBLE_VERSION" >> $GITHUB_ENV
+          echo "ANSIBLE_VERSION=$ANSIBLE_VERSION" >> $GITHUB_ENV
         id: test
 
       - name: Build and publish docker image

--- a/.github/workflows/build-and-publish-ansible.yaml
+++ b/.github/workflows/build-and-publish-ansible.yaml
@@ -27,12 +27,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/xima-media/debian-ansible
-
       - name: Build and publish docker image for testing
         uses: docker/build-push-action@v5
         with:
@@ -48,7 +42,7 @@ jobs:
           echo "ANSIBLE_VERSION=$ANSIBLE_VERSION" >> $GITHUB_ENV
         id: test
 
-      - name: Extract metadata (tags, labels) again to get ansible version tag
+      - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:

--- a/.github/workflows/build-and-publish-ansible.yaml
+++ b/.github/workflows/build-and-publish-ansible.yaml
@@ -43,7 +43,8 @@ jobs:
 
       - name: Test and get Ansible version
         run: |
-          echo "ANSIBLE_VERSION=$(docker run --rm ghcr.io/xima-media/debian-ansible:test ansible-community --version | cut -d' ' -f4-)" >> $GITHUB_ENV
+          ANSIBLE_VERSION="$(docker run --rm ghcr.io/xima-media/debian-ansible:test ansible-community --version | cut -d' ' -f4-)"
+          echo "$ANSIBLE_VERSION" >> $GITHUB_ENV
         id: test
 
       - name: Build and publish docker image

--- a/.github/workflows/build-and-publish-ansible.yaml
+++ b/.github/workflows/build-and-publish-ansible.yaml
@@ -44,6 +44,7 @@ jobs:
       - name: Test and get Ansible version
         run: |
           ANSIBLE_VERSION="$(docker run --rm ghcr.io/xima-media/debian-ansible:test ansible-community --version | cut -d' ' -f4-)"
+          echo "$ANSIBLE_VERSION"
           echo "$ANSIBLE_VERSION" >> $GITHUB_ENV
         id: test
 

--- a/.github/workflows/build-and-publish-ansible.yaml
+++ b/.github/workflows/build-and-publish-ansible.yaml
@@ -20,33 +20,44 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Get current date for build tag
-        id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
       - name: Log in to GitHub packages
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/xima-media/debian-ansible
 
+      - name: Build and publish docker image for testing
+        uses: docker/build-push-action@v5
+        with:
+          context: ./debian-ansible
+          push: true
+          tags: ghcr.io/xima-media/debian-ansible:test
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Test and get Ansible version
+        run: |
+          echo "ANSIBLE_VERSION=$(docker run --rm ghcr.io/xima-media/debian-ansible:test ansible-community --version | cut -d' ' -f4-)" >> $GITHUB_ENV
+        id: test
+
       - name: Build and publish docker image
         uses: docker/build-push-action@v5
         with:
           context: ./debian-ansible
           push: true
-          tags: ghcr.io/xima-media/debian-ansible:${{ steps.date.outputs.date }}
+          tags: ghcr.io/xima-media/debian-ansible:${{ steps.test.outputs.ANSIBLE_VERSION }}
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ghcr.io/xima-media/debian-ansible:${{ steps.date.outputs.date }}
+          image-ref: ghcr.io/xima-media/debian-ansible:${{ steps.test.outputs.ANSIBLE_VERSION }}
           format: 'sarif'
           output: 'debian-ansible.sarif'
           exit-code: '1'

--- a/.github/workflows/build-and-publish-ansible.yaml
+++ b/.github/workflows/build-and-publish-ansible.yaml
@@ -48,6 +48,12 @@ jobs:
           echo "ANSIBLE_VERSION=$ANSIBLE_VERSION" >> $GITHUB_ENV
         id: test
 
+      - name: Extract metadata (tags, labels) again to get ansible version tag
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/xima-media/debian-ansible
+
       - name: Build and publish docker image
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/build-and-publish-ansible.yaml
+++ b/.github/workflows/build-and-publish-ansible.yaml
@@ -53,13 +53,13 @@ jobs:
         with:
           context: ./debian-ansible
           push: true
-          tags: ghcr.io/xima-media/debian-ansible:${{ steps.test.outputs.ANSIBLE_VERSION }}
+          tags: ghcr.io/xima-media/debian-ansible:${{ env.ANSIBLE_VERSION }}
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ghcr.io/xima-media/debian-ansible:${{ steps.test.outputs.ANSIBLE_VERSION }}
+          image-ref: ghcr.io/xima-media/debian-ansible:${{ env.ANSIBLE_VERSION }}
           format: 'sarif'
           output: 'debian-ansible.sarif'
           exit-code: '1'


### PR DESCRIPTION
Ansible docker images are now tagged with the Ansible version provided by Debian stable. This improves the traceability of version changes and renovate bot updates.