### PR TITLE
feat: use Debian Trixie as base image

### DIFF
--- a/debian-ansible/Dockerfile
+++ b/debian-ansible/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM debian:trixie-slim
 
 COPY ./requirements.yml /tmp/requirements.yml
 
@@ -6,6 +6,7 @@ RUN apt-get update -yqq && \
     apt-get install openssh-client git curl wget unzip sshpass ansible python3-paramiko python3-passlib jq -yqq && \
     ansible-galaxy install -v -r /tmp/requirements.yml && \
     rm /tmp/requirements.yml && \
-    ansible --version
+    ansible --version && \
+    ansible-community --version
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
Ansible.posix and community.docker do not support version 2.14.16 provided by Debian bookworm