### PR TITLE
feat: update github actions to latest versions

### DIFF
--- a/.github/workflows/build-and-publish-ansible.yaml
+++ b/.github/workflows/build-and-publish-ansible.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Log in to GitHub packages
         uses: docker/login-action@v3
@@ -55,7 +55,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.30.0
         with:
           image-ref: ghcr.io/xima-media/ansible:${{ env.ANSIBLE_VERSION }}
           format: 'sarif'

--- a/.github/workflows/build-and-publish-composer.yaml
+++ b/.github/workflows/build-and-publish-composer.yaml
@@ -29,13 +29,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Composer version
         id: composer
         run: |
           VERSION=$(curl --silent https://api.github.com/repos/composer/composer/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
-          echo "::set-output name=version::$(echo ${VERSION})"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Log in to GitHub packages
         uses: docker/login-action@v3
@@ -61,7 +61,7 @@ jobs:
             COMPOSER_VERSION=${{ steps.composer.outputs.version }}
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.30.0
         with:
           image-ref: ${{ matrix.image }}:${{ steps.composer.outputs.version }}
           format: 'sarif'
@@ -72,7 +72,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         if: always()
         with:
           sarif_file: '${{ matrix.sarif }}'


### PR DESCRIPTION
- github/codeql-action/upload-sarif@v3
- aquasecurity/trivy-action@0.30.0
- actions/checkout@v4 and set-output command is deprecated