### PR TITLE
feat: add pa11y-ci docker image

### DIFF
--- a/.github/workflows/build-and-publish-pa11y.yaml
+++ b/.github/workflows/build-and-publish-pa11y.yaml
@@ -1,0 +1,41 @@
+name: Build and publish pa11y-ci image
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 2 1 * *"
+
+jobs:
+  build:
+    name: Build & push docker image
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub packages
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/xima-media/pa11y-ci
+
+      - name: Build and publish docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./pa11y-ci
+          push: true
+          tags: ghcr.io/xima-media/pa11y-ci:3.1.0
+          labels: ${{ steps.meta.outputs.labels }}

--- a/pa11y-ci/Dockerfile
+++ b/pa11y-ci/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:latest
+
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list && apt-get update && apt-get install -y google-chrome-stable libxss1 jq && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g pa11y-ci@3.1.0 puppeteer
+
+COPY config.json /pa11y-configs/.pa11yci
+
+COPY gitlab-accessibility.sh /gitlab-accessibility.sh

--- a/pa11y-ci/config.json
+++ b/pa11y-ci/config.json
@@ -1,0 +1,9 @@
+{
+	"defaults": {
+		"chromeLaunchConfig": {
+			"args": [
+				"--no-sandbox"
+			]
+		}
+	}
+}

--- a/pa11y-ci/gitlab-accessibility.sh
+++ b/pa11y-ci/gitlab-accessibility.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -o pipefail
+mkdir -p reports
+
+pa11y-ci -j --config "/pa11y-configs/.pa11yci" $@ > reports/gl-accessibility.json


### PR DESCRIPTION
This PR adds a new docker image for [pa11y-ci](https://github.com/pa11y/pa11y-ci), ready to use in GitLab CI. 

See https://docs.gitlab.com/ci/testing/accessibility_testing/